### PR TITLE
Update activesupport dependency to allow more modern versions

### DIFF
--- a/omdb-api.gemspec
+++ b/omdb-api.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   end
 
   spec.require_paths = ['lib']
-  spec.add_dependency 'activesupport', '~> 4.2.10'
+  spec.add_dependency 'activesupport', '>= 4.2.10'
   spec.add_dependency 'httparty', '~> 0.15'
   spec.add_development_dependency 'bundler'
 end


### PR DESCRIPTION
Hello,

I was having trouble installing this gem on a recent ruby because activesupport `~> 4.2.10` doesn't seem to work work in ruby 3.4.2. 

```
irb(main):001>  require 'omdb/api'
/Users/john/.asdf/installs/ruby/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-4.2.11.3/lib/active_support/core_ext/object/duplicable.rb:111:in '<class:BigDecimal>': undefined method 'new' for class BigDecimal (NoMethodError)
```

<details>
  <summary>Full Backtrace</summary>

```
irb(main):001>  require 'omdb/api'
/Users/john/.asdf/installs/ruby/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-4.2.11.3/lib/active_support/core_ext/object/duplicable.rb:111:in '<class:BigDecimal>': undefined method 'new' for class BigDecimal (NoMethodError)

    BigDecimal.new('4.56').dup
              ^^^^
	from /Users/john/.asdf/installs/ruby/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-4.2.11.3/lib/active_support/core_ext/object/duplicable.rb:106:in '<top (required)>'
	from <internal:/Users/john/.asdf/installs/ruby/3.4.2/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:136:in 'Kernel#require'
	from <internal:/Users/john/.asdf/installs/ruby/3.4.2/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:136:in 'Kernel#require'
	from /Users/john/.asdf/installs/ruby/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-4.2.11.3/lib/active_support/core_ext/object.rb:3:in '<top (required)>'
	from <internal:/Users/john/.asdf/installs/ruby/3.4.2/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:136:in 'Kernel#require'
	from <internal:/Users/john/.asdf/installs/ruby/3.4.2/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:136:in 'Kernel#require'
	from /Users/john/.asdf/installs/ruby/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-4.2.11.3/lib/active_support/core_ext.rb:2:in 'block in <top (required)>'
	from /Users/john/.asdf/installs/ruby/3.4.2/lib

```

</details>



This patch updates the requirement specification so new activesupports can be used. Tested locally and all tests passed on ruby 3.4.2 `activesupport (8.0.2)`. 

Thanks.

